### PR TITLE
Add GitHub Skills activity (fix missing activity #6)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -77,6 +77,14 @@ activities = {
     }
 }
 
+# Added: GitHub Skills activity requested by users (time-sensitive)
+activities["GitHub Skills"] = {
+    "description": "Practical workshops on Git, GitHub, and collaboration skills for college and careers",
+    "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+    "max_participants": 25,
+    "participants": []
+}
+
 
 @app.get("/")
 def root():


### PR DESCRIPTION
This PR adds the time-sensitive "GitHub Skills" activity to the in-memory `activities` list so students can sign up.

Changes:
- src/app.py: add `GitHub Skills` entry (Wednesdays, 3:30 PM - 5:00 PM, max 25)

Addresses: #6
